### PR TITLE
Fixed Issue #9

### DIFF
--- a/me7sum.c
+++ b/me7sum.c
@@ -740,10 +740,12 @@ out:
 	// free config
 	if(osconfig != 0) { free_properties(osconfig); }
 
-
+	// Made minor alterations in output to circumvent issue #9 @nyetwurk
 	if (ErrorsCorrected!=ErrorsFound) {
 		printf("\n*** WARNING! %d/%d uncorrected error(s) in %s! ***\n",
 			ErrorsFound-ErrorsCorrected, ErrorsFound, input);
+	} else if (ErrorsFound == 0){
+		printf("\n*** No errors were found and so no \"out.bin\" was generated.");
 	} else if (output) {
 		printf("\n*** DONE! %d/%d error(s) in %s corrected in %s! ***\n", ErrorsCorrected,
 			ErrorsFound, input, output);


### PR DESCRIPTION
Now outputs an error message if the file being checksummed has no checksums to correct.

Tested using Checksummed and Non-Checksummed Polo GTI 9N3 Map files I've hosted in my GitHub repo.
![Checksummed File Output](https://user-images.githubusercontent.com/52194584/73284893-e56eda00-41fd-11ea-920e-570bfa92900f.png)
![Checksummed File ls Confirmation](https://user-images.githubusercontent.com/52194584/73284934-f3245f80-41fd-11ea-9efb-b752e330e3a2.png)
![Non-Checksummed File Output](https://user-images.githubusercontent.com/52194584/73284946-f7e91380-41fd-11ea-933a-197be53767e5.png)
![Non-Checksummed out.bin Highlighted Confirmation](https://user-images.githubusercontent.com/52194584/73284950-f881aa00-41fd-11ea-969c-31f5f3a24284.png)



